### PR TITLE
Fix tree

### DIFF
--- a/srcs/parsing/make_tree/make_tree.c
+++ b/srcs/parsing/make_tree/make_tree.c
@@ -100,11 +100,21 @@ static t_tree	*add_subredirection(size_t *i,
 
 static t_tree	*down(t_tree *root, t_tree *new)
 {
+	t_tree	*tmp;
+
 	if (NULL == root)
 		return (new);
 	if (root->left == NULL)
 	{
 		root->left = new;
+		return (root);
+	}
+	if (root->right)
+	{
+		tmp = root->right;
+		while (tmp->right)
+			tmp = tmp->right;
+		tmp->right = new;
 		return (root);
 	}
 	root->right = new;

--- a/srcs/prompt/prompt.c
+++ b/srcs/prompt/prompt.c
@@ -52,7 +52,7 @@ int	prompt(t_param *param)
 	return (free_fd(&fd, 1));
 }
 
-static void end_of_file(t_param *param)
+static void	end_of_file(t_param *param)
 {
 	ft_printf("Exit\n");
 	clear_env(&param->env);


### PR DESCRIPTION
# fix tree:
## command line
``echo 1&&(echo 2||echo 3) | (echo 4 && echo5)``
### **now:**
```
                  echo5 
            &&
                  echo 4 
      |
                  echo 3 
            ||
                  echo 2 
&&
      echo 1 
```
### **before:**
```
            echo5 
      &&
            echo 4 
&&
      echo 1 

```